### PR TITLE
improved output

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 			if diff == nil {
 				return nil
 			}
+			fmt.Println("some tests are slower than previous.")
 			for _, output := range diff {
 				fmt.Println(output)
 			}

--- a/usecase/compare.go
+++ b/usecase/compare.go
@@ -27,7 +27,6 @@ func CompareWithPrev(prevFileName string, currentFileName string, l loader.Loade
 	for _, testData := range currentTestData {
 		if prevElapsed, exist := prevTestMap[testData.Name]; exist {
 			if testData.IsSlowerThan(prevElapsed, border) {
-				//TODO: Improve redundant output.
 				diff = append(diff, fmt.Sprintf("'%s', prev: %s, current: %s", testData.Name, strconv.FormatFloat(prevElapsed, 'f', -1, 64)+"s", strconv.FormatFloat(testData.Elapsed, 'f', -1, 64)+"s"))
 			}
 		}

--- a/usecase/compare.go
+++ b/usecase/compare.go
@@ -28,7 +28,7 @@ func CompareWithPrev(prevFileName string, currentFileName string, l loader.Loade
 		if prevElapsed, exist := prevTestMap[testData.Name]; exist {
 			if testData.IsSlowerThan(prevElapsed, border) {
 				//TODO: Improve redundant output.
-				diff = append(diff, fmt.Sprintf("'%s' is slower than previous. prev: %s, current: %s", testData.Name, strconv.FormatFloat(prevElapsed, 'f', -1, 64)+"s", strconv.FormatFloat(testData.Elapsed, 'f', -1, 64)+"s"))
+				diff = append(diff, fmt.Sprintf("'%s', prev: %s, current: %s", testData.Name, strconv.FormatFloat(prevElapsed, 'f', -1, 64)+"s", strconv.FormatFloat(testData.Elapsed, 'f', -1, 64)+"s"))
 			}
 		}
 	}

--- a/usecase/compare_test.go
+++ b/usecase/compare_test.go
@@ -24,9 +24,9 @@ func TestCompareWithPrev(t *testing.T) {
 				currentFileName: "testdata/slower.txt",
 			},
 			wantDiff: []string{
-				"'TestAdd' is slower than previous. prev: 0s, current: 2s",
-				"'TestAdd/Can_add_up_two_numbers.' is slower than previous. prev: 0s, current: 1s",
-				"'TestAdd/Can_add_up_two_numbers(includes_negative_value).' is slower than previous. prev: 0s, current: 1s",
+				"'TestAdd', prev: 0s, current: 2s",
+				"'TestAdd/Can_add_up_two_numbers.', prev: 0s, current: 1s",
+				"'TestAdd/Can_add_up_two_numbers(includes_negative_value).', prev: 0s, current: 1s",
 			},
 		},
 		{


### PR DESCRIPTION
Before
```
'TestAdd' is slower than previous. prev: 0s, current: 2s
'TestAdd/Can_add_up_two_numbers(includes_negative_value).' is slower than previous. prev: 0s, current: 1s
```

Now
```
some tests are slower than previous.
'TestAdd', prev: 0s, current: 2s
'TestAdd/Can_add_up_two_numbers(includes_negative_value).', prev: 0s, current: 1s
exit status 1
```